### PR TITLE
fix: added bytearray loop to ble from usb

### DIFF
--- a/tourboxelite/device_ble.py
+++ b/tourboxelite/device_ble.py
@@ -114,7 +114,8 @@ class TourBoxBLE(TourBoxBase):
 
         Wraps the base class process_button_code method for BLE notifications.
         """
-        self.process_button_code(data)
+        for byte in data:
+            self.process_button_code(bytearray([byte]))
 
     async def send_haptic_config(self):
         """Send haptic configuration to the device


### PR DESCRIPTION
On bluetooth was noticing some button code warnings from quick actions causing some sticky buttons. Replicatable by spamming on eg the tall and top buttons.

```
Jan 16 12:05:54 <> python[130234]: 2026-01-16 12:05:54,106 - tourboxelite.device_base - WARNING - Unknown button code: 0002
Jan 16 12:05:54 <> python[130234]: 2026-01-16 12:05:54,252 - tourboxelite.device_base - INFO - 82 -> KEY_LEFTSHIFT:RELEASE
Jan 16 12:05:54 <> python[130234]: 2026-01-16 12:05:54,300 - tourboxelite.device_base - INFO - 80 -> KEY_LEFTALT:RELEASE
Jan 16 12:05:54 <> python[130234]: 2026-01-16 12:05:54,349 - tourboxelite.device_base - INFO - 00 -> KEY_LEFTALT:PRESS
Jan 16 12:05:54 <> python[130234]: 2026-01-16 12:05:54,447 - tourboxelite.device_base - INFO - 02 -> KEY_LEFTSHIFT:PRESS
Jan 16 12:05:54 <> python[130234]: 2026-01-16 12:05:54,544 - tourboxelite.device_base - INFO - 82 -> KEY_LEFTSHIFT:RELEASE
Jan 16 12:05:54 <> python[130234]: 2026-01-16 12:05:54,643 - tourboxelite.device_base - INFO - 02 -> KEY_LEFTSHIFT:PRESS
Jan 16 12:05:54 <> python[130234]: 2026-01-16 12:05:54,740 - tourboxelite.device_base - INFO - 80 -> KEY_LEFTALT:RELEASE
Jan 16 12:05:54 <> python[130234]: 2026-01-16 12:05:54,788 - tourboxelite.device_base - INFO - 82 -> KEY_LEFTSHIFT:RELEASE
Jan 16 12:05:54 <> python[130234]: 2026-01-16 12:05:54,838 - tourboxelite.device_base - INFO - 00 -> KEY_LEFTALT:PRESS
Jan 16 12:05:54 <> python[130234]: 2026-01-16 12:05:54,886 - tourboxelite.device_base - INFO - 02 -> KEY_LEFTSHIFT:PRESS
Jan 16 12:05:54 <> python[130234]: 2026-01-16 12:05:54,987 - tourboxelite.device_base - INFO - 80 -> KEY_LEFTALT:RELEASE
Jan 16 12:05:55 <> python[130234]: 2026-01-16 12:05:55,033 - tourboxelite.device_base - WARNING - Unknown button code: 0082
Jan 16 12:05:55 <> python[130234]: 2026-01-16 12:05:55,129 - tourboxelite.device_base - INFO - 02 -> KEY_LEFTSHIFT:PRESS
Jan 16 12:05:55 <> python[130234]: 2026-01-16 12:05:55,129 - tourboxelite.device_base - INFO - 80 -> KEY_LEFTALT:RELEASE
Jan 16 12:05:55 <> python[130234]: 2026-01-16 12:05:55,178 - tourboxelite.device_base - INFO - 82 -> KEY_LEFTSHIFT:RELEASE
```

Noticed that they looked like pairs of bytes and that `device_usb` had handling to iterate over the incoming bytes so added that to `device_ble` too which removes the issue for me. Ofc happy for other solutions, this was just quick and easy.

```
Jan 16 12:07:28 <> python[131608]: 2026-01-16 12:07:28,437 - tourboxelite.device_base - INFO - 00 -> KEY_LEFTALT:PRESS
Jan 16 12:07:28 <> python[131608]: 2026-01-16 12:07:28,487 - tourboxelite.device_base - INFO - 02 -> KEY_LEFTSHIFT:PRESS
Jan 16 12:07:28 <> python[131608]: 2026-01-16 12:07:28,632 - tourboxelite.device_base - INFO - 80 -> KEY_LEFTALT:RELEASE
Jan 16 12:07:28 <> python[131608]: 2026-01-16 12:07:28,632 - tourboxelite.device_base - INFO - 82 -> KEY_LEFTSHIFT:RELEASE
Jan 16 12:07:28 <> python[131608]: 2026-01-16 12:07:28,632 - tourboxelite.device_base - INFO - 00 -> KEY_LEFTALT:PRESS
Jan 16 12:07:28 <> python[131608]: 2026-01-16 12:07:28,730 - tourboxelite.device_base - INFO - 02 -> KEY_LEFTSHIFT:PRESS
Jan 16 12:07:28 <> python[131608]: 2026-01-16 12:07:28,778 - tourboxelite.device_base - INFO - 80 -> KEY_LEFTALT:RELEASE
Jan 16 12:07:28 <> python[131608]: 2026-01-16 12:07:28,827 - tourboxelite.device_base - INFO - 00 -> KEY_LEFTALT:PRESS
Jan 16 12:07:28 <> python[131608]: 2026-01-16 12:07:28,877 - tourboxelite.device_base - INFO - 82 -> KEY_LEFTSHIFT:RELEASE
Jan 16 12:07:28 <> python[131608]: 2026-01-16 12:07:28,925 - tourboxelite.device_base - INFO - 02 -> KEY_LEFTSHIFT:PRESS
Jan 16 12:07:29 <> python[131608]: 2026-01-16 12:07:29,022 - tourboxelite.device_base - INFO - 80 -> KEY_LEFTALT:RELEASE
Jan 16 12:07:29 <> python[131608]: 2026-01-16 12:07:29,022 - tourboxelite.device_base - INFO - 00 -> KEY_LEFTALT:PRESS
Jan 16 12:07:29 <> python[131608]: 2026-01-16 12:07:29,072 - tourboxelite.device_base - INFO - 82 -> KEY_LEFTSHIFT:RELEASE
Jan 16 12:07:29 <> python[131608]: 2026-01-16 12:07:29,168 - tourboxelite.device_base - INFO - 02 -> KEY_LEFTSHIFT:PRESS
Jan 16 12:07:29 <> python[131608]: 2026-01-16 12:07:29,315 - tourboxelite.device_base - INFO - 82 -> KEY_LEFTSHIFT:RELEASE
Jan 16 12:07:29 <> python[131608]: 2026-01-16 12:07:29,363 - tourboxelite.device_base - INFO - 02 -> KEY_LEFTSHIFT:PRESS
Jan 16 12:07:29 <> python[131608]: 2026-01-16 12:07:29,363 - tourboxelite.device_base - INFO - 80 -> KEY_LEFTALT:RELEASE
Jan 16 12:07:29 <> python[131608]: 2026-01-16 12:07:29,461 - tourboxelite.device_base - INFO - 00 -> KEY_LEFTALT:PRESS
Jan 16 12:07:29 <> python[131608]: 2026-01-16 12:07:29,510 - tourboxelite.device_base - INFO - 82 -> KEY_LEFTSHIFT:RELEASE
```