### PR TITLE
fix: unlock device bytes inadvertently caused presses

### DIFF
--- a/tourboxelite/device_ble.py
+++ b/tourboxelite/device_ble.py
@@ -204,12 +204,12 @@ class TourBoxBLE(TourBoxBase):
                 self.client = client
                 logger.info("Connected to TourBox Elite")
 
+                # Unlock device and send configuration
+                await self.unlock_device()
+
                 # Enable notifications
                 logger.info("Enabling button notifications...")
                 await client.start_notify(NOTIFY_CHAR, self.notification_handler)
-
-                # Unlock device and send configuration
-                await self.unlock_device()
 
                 logger.info("TourBox Elite ready! Press buttons to generate input events.")
                 print("TourBox Elite connected and ready!")


### PR DESCRIPTION
Fix issue caused by https://github.com/AndyCappDev/tourbox-linux/pull/17 where the unlock code was interpreted as button presses

Apologies for missing this in the previous one