### PR TITLE
Fix auto-detect locking transport at startup; support USB hot-plug

### DIFF
--- a/tuxbox/__main__.py
+++ b/tuxbox/__main__.py
@@ -30,6 +30,16 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_USB_PORT = "/dev/ttyACM0"
 
+# How often the auto-detect supervisor rescans for a USB TourBox while the
+# BLE transport is active. Cheap glob check first; full probe only if a
+# /dev/ttyACM* device is actually present.
+USB_RESCAN_INTERVAL = 3.0
+
+# Grace period to let the BLE driver wind down after kill_now is set before
+# we forcibly cancel its task. Bleak scans can be up to ~10s, so this needs
+# headroom.
+BLE_SHUTDOWN_TIMEOUT = 15.0
+
 # Unlock command used to probe for TourBox
 UNLOCK_COMMAND = bytes.fromhex("5500078894001afe")
 
@@ -127,6 +137,82 @@ def find_tuxbox_usb_port(configured_port: str = None) -> str:
     return None
 
 
+async def _wait_for_ble_to_stop(ble_task):
+    """Wait for a TuxBoxBLE.start() task to wind down after kill_now is set.
+
+    Falls back to cancellation if the driver does not stop within
+    BLE_SHUTDOWN_TIMEOUT (e.g. stuck mid-scan inside bleak).
+    """
+    try:
+        await asyncio.wait_for(asyncio.shield(ble_task), timeout=BLE_SHUTDOWN_TIMEOUT)
+    except asyncio.TimeoutError:
+        logger.warning(
+            f"BLE driver did not exit gracefully within {BLE_SHUTDOWN_TIMEOUT:.0f}s; "
+            "cancelling"
+        )
+        ble_task.cancel()
+        try:
+            await ble_task
+        except (asyncio.CancelledError, Exception):
+            pass
+
+
+async def auto_detect_loop(args, configured_usb_port):
+    """Auto-detect transport with USB hot-plug awareness.
+
+    Once USB is selected the supervisor steps out of the way: TuxBoxUSB has
+    its own internal hot-plug + reconnect loop and handles cable
+    disconnect/reconnect itself.
+
+    When USB is absent at startup, the supervisor runs TuxBoxBLE alongside
+    a watcher that promotes to USB the moment a TourBox-responsive
+    /dev/ttyACM* device appears. This is the common case for users who
+    log in before plugging the cable in, or who share the device across
+    multiple computers.
+    """
+    from .device_usb import TuxBoxUSB
+    from .device_ble import TuxBoxBLE
+
+    while True:
+        usb_port = find_tuxbox_usb_port(configured_usb_port)
+
+        if usb_port:
+            logger.info(f"Auto-detected TourBox at {usb_port}")
+            print(f"Found TourBox on USB ({usb_port})")
+            await TuxBoxUSB(port=usb_port, config_path=args.config).start()
+            return
+
+        logger.info("No TourBox USB device found, using BLE")
+        print("No USB device found, using Bluetooth")
+        ble_driver = TuxBoxBLE(config_path=args.config)
+        ble_task = asyncio.create_task(ble_driver.start())
+        promoted_to_usb = False
+
+        try:
+            while not ble_task.done():
+                await asyncio.sleep(USB_RESCAN_INTERVAL)
+                # Cheap glob first; only run the full probe if a port exists
+                if not glob.glob("/dev/ttyACM*"):
+                    continue
+                detected = find_tuxbox_usb_port(configured_usb_port)
+                if not detected:
+                    continue
+                logger.info(
+                    f"USB device detected at {detected} - "
+                    "switching from BLE to USB"
+                )
+                print("\nUSB cable detected - switching to USB connection...")
+                ble_driver.killer.kill_now = True
+                promoted_to_usb = True
+                break
+        finally:
+            await _wait_for_ble_to_stop(ble_task)
+
+        if not promoted_to_usb:
+            # BLE task ended on its own (signal received, or unrecoverable error).
+            return
+
+
 def main():
     """Main entry point with auto-detection"""
 
@@ -171,56 +257,42 @@ def main():
         print("Error: Cannot specify both --usb and --ble")
         sys.exit(1)
 
-    if args.usb:
-        mode = 'usb'
-        logger.info("USB mode forced via --usb flag")
-    elif args.ble:
-        mode = 'ble'
-        logger.info("BLE mode forced via --ble flag")
-    else:
-        # Auto-detect: scan for TourBox USB device
-        print("Scanning for TourBox...")
-        detected_port = find_tuxbox_usb_port(usb_port)
-        if detected_port:
-            mode = 'usb'
-            usb_port = detected_port
-            logger.info(f"Auto-detected TourBox at {usb_port}")
-            print(f"Found TourBox on USB ({usb_port})")
-        else:
-            mode = 'ble'
-            logger.info("No TourBox USB device found, using BLE")
-            print("No USB device found, using Bluetooth")
+    try:
+        if args.usb:
+            logger.info("USB mode forced via --usb flag")
+            from .device_usb import TuxBoxUSB
 
-    # Start appropriate driver
-    if mode == 'usb':
-        from .device_usb import TuxBoxUSB
+            # Scan for the device if no explicit port was given
+            if not args.port:
+                detected_port = find_tuxbox_usb_port(usb_port)
+                if detected_port:
+                    usb_port = detected_port
+                elif not os.path.exists(usb_port):
+                    print("Error: No TourBox found on USB")
+                    print("Is the TourBox connected via USB cable?")
+                    print("Checked: /dev/ttyACM* devices")
+                    sys.exit(1)
 
-        # If USB mode was forced, scan for the device
-        if args.usb and not args.port:
-            detected_port = find_tuxbox_usb_port(usb_port)
-            if detected_port:
-                usb_port = detected_port
-            elif not os.path.exists(usb_port):
-                print(f"Error: No TourBox found on USB")
-                print("Is the TourBox connected via USB cable?")
-                print(f"Checked: /dev/ttyACM* devices")
+            if not os.path.exists(usb_port):
+                print(f"Error: USB port {usb_port} not found")
+                print("Is the TourBox connected via USB?")
                 sys.exit(1)
 
-        if not os.path.exists(usb_port):
-            print(f"Error: USB port {usb_port} not found")
-            print("Is the TourBox connected via USB?")
-            sys.exit(1)
+            asyncio.run(TuxBoxUSB(port=usb_port, config_path=args.config).start())
 
-        driver = TuxBoxUSB(port=usb_port, config_path=args.config)
+        elif args.ble:
+            logger.info("BLE mode forced via --ble flag")
+            from .device_ble import TuxBoxBLE
+            asyncio.run(TuxBoxBLE(config_path=args.config).start())
 
-    else:  # BLE mode
-        from .device_ble import TuxBoxBLE
+        else:
+            # Auto-detect with USB hot-plug awareness. The supervisor stays
+            # alive across the full session so that plugging the cable in
+            # after login (or replugging after using the device on another
+            # computer) is picked up automatically without a service restart.
+            print("Scanning for TourBox...")
+            asyncio.run(auto_detect_loop(args, usb_port))
 
-        driver = TuxBoxBLE(config_path=args.config)
-
-    # Run the driver
-    try:
-        asyncio.run(driver.start())
     except KeyboardInterrupt:
         print("\nExited by user")
     except Exception as e:


### PR DESCRIPTION
### Summary

`__main__.py` ran `find_tuxbox_usb_port()` exactly once at startup. If the cable wasn't plugged in at that moment, the driver fell into BLE-only mode permanently. No rescan, no recovery short of a service restart.

This patch wraps the auto-detect path in a small supervisor that promotes BLE to USB as soon as a TourBox-responsive `/dev/ttyACM*` device appears. `--usb` and `--ble` flags retain their current single-transport semantics. No changes to `device_usb.py`, `device_ble.py`, or any other module.

Proposed fix for issue #42 

### Root cause

`__main__.py:183` (pre-patch):

```python
detected_port = find_tuxbox_usb_port(usb_port)
if detected_port:
    mode = 'usb'
    ...
else:
    mode = 'ble'
    ...
# mode is then used to pick a single driver class, instantiated once.
```

There is no rescan after this point. The systemd unit fires on `graphical-session.target` at login, so anyone who plugs in their cable after logging in, or who shares the device with another machine and brings it back, ends up in BLE-only limbo while a perfectly healthy `/dev/ttyACM0` sits unused.

`device_usb.py:start()` already has a hot-plug + reconnect loop (lines 327-330 wait for the port to appear, lines 338-343 do exponential backoff on disconnect). The fix is purely about letting `TuxBoxUSB` actually get instantiated when the cable shows up late.

### Fix

A new `auto_detect_loop()` coroutine in `__main__.py`, only invoked in the auto-detect path, never with `--usb` or `--ble`:

1. Probe for USB. If a TourBox-responsive ACM device is present, run `TuxBoxUSB`, which already handles cable disconnect/reconnect itself.
2. If not, run `TuxBoxBLE` as a task, with a watcher that polls `glob.glob("/dev/ttyACM*")` every 3s. Cheap glob first; only run the full unlock-probe if a port actually appears, to avoid hammering arbitrary CDC-ACM devices.
3. When USB appears, set `ble_driver.killer.kill_now = True`. This is the existing graceful-shutdown signal, the same mechanism the service already uses for SIGTERM. Wait up to `BLE_SHUTDOWN_TIMEOUT` (15s) for clean exit, fall back to task cancellation if bleak is mid-scan.
4. Loop back, find USB, run `TuxBoxUSB`.

Two small constants added at module level, matching the existing convention for internal timing values like `device_usb.py:64 self.reconnect_delay = 5.0`:

- `USB_RESCAN_INTERVAL = 3.0`: polling cadence while in BLE mode.
- `BLE_SHUTDOWN_TIMEOUT = 15.0`: grace period before falling back to cancel.

These are not surfaced in `[device]` config; they're internal tuning values, not user-facing knobs.

### Behavioral changes

| Scenario | Before | After |
|---|---|---|
| Cable plugged in at service start | USB mode | USB mode (unchanged) |
| Cable absent at start, never plugged in | BLE mode forever | BLE mode forever (unchanged) |
| Cable plugged in after start (login, replug, share with Mac/iPad) | Stuck in BLE mode forever | BLE to USB promotion in 3-10s |
| Cable unplugged while running USB; user replugs same machine | Existing internal reconnect loop | (unchanged: `device_usb.py` already handles this) |
| Cable unplugged while running USB; user wants BLE without replugging | Service restart required | Service restart required (see "Pre-existing behavior preserved" below) |
| `--usb` flag | Forced USB, single-shot | (unchanged) |
| `--ble` flag | Forced BLE, single-shot | (unchanged) |

### Test matrix (local, TourBox Elite Plus on CachyOS / KDE Wayland)

All five exercised against the running systemd user service or in foreground. Logs are real journal excerpts.

**1. USB present at startup**

```
__main__   Found TourBox at /dev/ttyACM0 (26 bytes)
__main__   Auto-detected TourBox at /dev/ttyACM0
device_usb Unlock response (26 bytes): 78... (remainder redacted)
device_usb TourBox Elite USB ready!
```

**2. Replug while running USB** (validates pre-existing `device_usb.py` reconnect logic; untouched by this PR but verified still working)

```
20:30:37 device_usb USB device I/O error (errno 5); treating as disconnect
20:30:37 device_usb USB connection closed
20:30:37 device_usb Attempting to reconnect in 5.0 seconds...
20:30:42 device_usb Connecting to TourBox Elite at /dev/ttyACM0...
20:30:43 device_usb TourBox Elite USB ready!
```
~5s outage, fully automatic.

**3. Cold start with no cable, then plug in (the case this PR fixes)**

```
20:31:45 __main__   No TourBox USB device found, using BLE
20:31:45 device_ble Scanning for TourBox devices (timeout: 10.0s)...
... [BLE scan loop, watcher polling every 3s in parallel] ...
20:32:51 __main__   Found TourBox at /dev/ttyACM0 (26 bytes)
20:32:51 __main__   USB device detected at /dev/ttyACM0 - switching from BLE to USB
20:32:57 device_ble TuxBox BLE driver stopped              # clean shutdown via kill_now
20:32:58 __main__   Auto-detected TourBox at /dev/ttyACM0
20:32:59 device_usb TourBox Elite USB ready!
```
~7s end-to-end from cable plug-in to USB-ready. BLE shutdown well within the 15s grace window.

**4. `--usb` flag (regression check on the dispatch reorganization)**

```
__main__   USB mode forced via --usb flag
__main__   Trying configured port: /dev/ttyACM0
__main__   Found TourBox at /dev/ttyACM0 (26 bytes)
device_usb TourBox Elite USB ready!
```
Same path as before, dispatched from the new `if args.usb:` branch instead of the old shared `if mode == 'usb':` block.

**5. `--ble` flag (regression check on the dispatch reorganization)**

```
__main__   BLE mode forced via --ble flag
device_ble Loaded 6 profiles
device_ble Scanning for TourBox devices (timeout: 10.0s)...
```
Cleanly enters BLE-scan mode. Did not actually find the device in this run because the cable was plugged in. TourBox Elite Plus does not advertise BLE while USB is connected, which is device behavior unrelated to this PR.

> Note on log wording: the string `TourBox Elite USB ready!` in the excerpts above comes from `device_usb.py:209` on master, where it is hardcoded. The same message is logged for any USB-connected model (Elite, Elite Plus, Neo, Lite). The supervisor in this PR does not introspect device type. It hands off to `TuxBoxUSB` once a USB-responsive device is found, so the fix applies to every USB-supported model. Tested locally on Elite Plus.

### Test plan (for reviewers without an Elite Plus)

- [ ] `python -m tuxbox -v --usb` still works as before with the cable plugged in.
- [ ] `python -m tuxbox -v --ble` still works as before with USB unplugged.
- [ ] `python -m tuxbox -v` (auto-detect) with USB plugged in connects via USB.
- [ ] `python -m tuxbox -v` (auto-detect) with USB unplugged enters BLE mode. Plug in cable. Within ~10s, logs show `USB device detected ... - switching from BLE to USB` followed by `TourBox Elite USB ready!`.
- [ ] Service-based: `systemctl --user restart tuxbox` with no cable, then plug it in. Same behavior.

### Pre-existing behavior preserved (out of scope here)

This PR fixes the BLE-to-USB direction. The reverse (running USB, cable unplugged, switch to BLE on the same machine without replugging) is unchanged from master and still requires a service restart. Once `TuxBoxUSB` is instantiated, `device_usb.py:start()`'s internal loop (lines 327-330 on master) waits indefinitely for `/dev/ttyACM*` to come back. Nothing in master ever reroutes to BLE either, so this is a pre-existing limitation, not something this PR introduces.

Kept out of scope deliberately, to keep the testing surface small and the fix focused on the much more common bug (cable plugged in late or after a replug). The asymmetry also mirrors what is likely the dominant real-world workflow: users plug the cable in to use the device locally, and unplug to take it to a different machine, not to switch to cordless on the same machine. While the cable is gone, BLE on this machine usually can't see the device anyway because it's paired/connected elsewhere.

A symmetric supervisor (USB-to-BLE promotion after a grace period for absent `/dev/ttyACM*`) is a clean follow-up if it turns out users want it: same watcher pattern, with a configurable grace period to distinguish brief USB glitches from real disconnects. Happy to do it as a separate PR if asked.

### Other items left for follow-up

- **Probe candidate filtering.** While running BLE, the supervisor calls `find_tuxbox_usb_port()` every `USB_RESCAN_INTERVAL` (3s), which probes every `/dev/ttyACM*` it finds, writing the 8-byte unlock command to each. If a non-TourBox CDC-ACM device (Arduino, 3D printer, modem) is also present on the system, it gets that write every 3s while the supervisor is in BLE mode. The bytes are harmless to virtually every other CDC-ACM device, and the existing one-shot `find_tuxbox_usb_port()` already has the same property at startup. This PR just runs it periodically. A clean follow-up is to either (a) skip ports that already failed to probe within the current BLE session and only retry them after they disappear and come back, or (b) filter candidate ports by USB `VID:PID` (`c251:2005` for Elite Plus, etc.) via sysfs before probing. Deferred to keep this PR focused.

- **Event-driven detection (pyudev or similar) instead of polling.** The watcher uses a 3-second `glob.glob("/dev/ttyACM*")` poll because that needs no new dependencies (current runtime deps are `bleak`, `evdev`, `pyserial`). A pyudev subscription would be event-driven, sub-second response, and zero idle CPU; same for an `inotify` watch on `/dev`. Skipped here because adding a runtime dep felt out of proportion for a small bugfix PR and the polling cost is negligible against the BLE scan loop running in parallel. Naturally pairs with the probe-filtering item above as a single "smarter device discovery" follow-up if the maintainer prefers that direction.

### What this PR does not include

- No changes to `device_usb.py`, `device_ble.py`, `device_base.py`, or `config_loader.py`.
- No new config options.
- No new dependencies.
- No formal test harness, kept consistent with the project's existing testing approach (manual `*_test_tuxbox.py` scripts plus dogfooding). Happy to add one if the maintainer would like.

### AI use disclosure

The bug was identified, the fix designed, and the issue and PR text were drafted with assistance from an LLM (Claude). All hardware testing, log analysis, code review, and end-to-end validation against the running driver on my own Linux machine were done manually.