### PR TITLE
Filter USB unlock probe to known TourBox VID:PID pairs

### DIFF
--- a/tuxbox/__main__.py
+++ b/tuxbox/__main__.py
@@ -43,6 +43,109 @@ BLE_SHUTDOWN_TIMEOUT = 15.0
 # Unlock command used to probe for TourBox
 UNLOCK_COMMAND = bytes.fromhex("5500078894001afe")
 
+# Known TourBox USB (vid, pid) pairs. The supervisor uses these to filter
+# /dev/ttyACM* candidates before sending the unlock probe, so devices that
+# obviously aren't TourBoxes (Arduinos, 3D printer boards, modems) don't
+# receive the unlock bytes every USB_RESCAN_INTERVAL.
+#
+# Conservative on purpose: the only entries here are pairs we have direct
+# hardware evidence for. The manufacturer-string fallback below catches
+# unrecognized firmware variants without weakening the filter for genuine
+# non-TourBox hardware. If sysfs lookup itself fails (older kernels, unusual
+# udev), the resolver returns None and the caller falls through to probing.
+TOURBOX_USB_IDS = frozenset([
+    (0xc251, 0x2005),  # TourBox Elite, Elite Plus (TourBoxTech via Keil VID)
+])
+
+# Substring (case-insensitive) checked against the device's iManufacturer
+# string from sysfs when the (vid, pid) pair isn't in the allowlist above.
+TOURBOX_MANUFACTURER_HINT = "tourbox"
+
+# Ports we've already logged a "not-a-TourBox" skip for. The supervisor
+# rescans every USB_RESCAN_INTERVAL while in BLE mode, so without this
+# guard a non-TourBox CDC-ACM device on the bus would emit a skip log
+# every tick. First-sight only is enough to surface the device.
+_SKIPPED_PORTS_LOGGED = set()
+
+
+def _read_sysfs_usb_attrs(port: str):
+    """Read USB descriptor attributes for a /dev/ttyACM* port via sysfs.
+
+    For a CDC-ACM device, /sys/class/tty/<name>/device is the interface
+    directory; idVendor/idProduct/manufacturer live one level up on the
+    parent USB device directory.
+
+    Returns a dict with any subset of {vid, pid, manufacturer} that could
+    be read, or None if no attributes were readable. None means the caller
+    should fall through to probing (preserving master behavior on systems
+    where sysfs isn't usable for whatever reason).
+    """
+    try:
+        name = os.path.basename(port)
+        device_dir = os.path.realpath(f"/sys/class/tty/{name}/device")
+        usb_dev_dir = os.path.dirname(device_dir)
+        out = {}
+        for key, fname in (("vid", "idVendor"), ("pid", "idProduct")):
+            try:
+                with open(os.path.join(usb_dev_dir, fname)) as f:
+                    out[key] = int(f.read().strip(), 16)
+            except (OSError, ValueError):
+                pass
+        try:
+            with open(os.path.join(usb_dev_dir, "manufacturer")) as f:
+                out["manufacturer"] = f.read().strip()
+        except OSError:
+            pass
+        return out if out else None
+    except Exception:
+        return None
+
+
+def _is_likely_tourbox(port: str):
+    """Decide whether `port` is worth sending the unlock probe to.
+
+    Returns True if the port matches a known TourBox (vid, pid) pair or its
+    iManufacturer string contains the TourBox hint. Returns False if sysfs
+    positively identifies the port as something else. Returns None if sysfs
+    isn't usable for this port, in which case the caller should fall through
+    to probing.
+    """
+    attrs = _read_sysfs_usb_attrs(port)
+    if not attrs:
+        return None
+    vid = attrs.get("vid")
+    pid = attrs.get("pid")
+    if vid is not None and pid is not None and (vid, pid) in TOURBOX_USB_IDS:
+        return True
+    mfr = attrs.get("manufacturer", "")
+    if mfr and TOURBOX_MANUFACTURER_HINT in mfr.lower():
+        if vid is not None and pid is not None:
+            logger.info(
+                f"{port} reports unrecognized USB ID {vid:04x}:{pid:04x} "
+                f"with manufacturer {mfr!r}; probing anyway"
+            )
+        return True
+    if vid is None or pid is None:
+        # Partial sysfs read; safer to fall through and probe.
+        return None
+    return False
+
+
+def _probe_if_eligible(port: str) -> bool:
+    """Apply the not-a-TourBox filter, then probe if the port survives.
+
+    Returns True if the port both passes the filter (or sysfs is unusable
+    and we fall through) and responds to the unlock command. False means
+    either sysfs identified the port as something else, or the probe came
+    back empty.
+    """
+    if _is_likely_tourbox(port) is False:
+        if port not in _SKIPPED_PORTS_LOGGED:
+            logger.debug(f"  Skipping {port}: USB IDs do not match TourBox")
+            _SKIPPED_PORTS_LOGGED.add(port)
+        return False
+    return probe_usb_device(port)
+
 
 def probe_usb_device(port: str) -> bool:
     """Probe a USB serial port to check if it's a TourBox Elite
@@ -111,10 +214,10 @@ def find_tuxbox_usb_port(configured_port: str = None) -> str:
     Returns:
         Port path if found, None otherwise
     """
-    # If a specific port is configured, try it first
+    # If a specific port is configured, try it first.
     if configured_port and os.path.exists(configured_port):
         logger.debug(f"Trying configured port: {configured_port}")
-        if probe_usb_device(configured_port):
+        if _probe_if_eligible(configured_port):
             return configured_port
 
     # Scan all ttyACM devices
@@ -131,7 +234,7 @@ def find_tuxbox_usb_port(configured_port: str = None) -> str:
         if port == configured_port:
             continue
 
-        if probe_usb_device(port):
+        if _probe_if_eligible(port):
             return port
 
     return None


### PR DESCRIPTION
### Summary

Follow-up to #43 (auto-detect hot-plug fix). That PR's "Other items left for follow-up" section flagged that the supervisor's USB rescan probes every `/dev/ttyACM*` device it finds, writing the unlock command to each one every `USB_RESCAN_INTERVAL` while in BLE mode. Harmless to virtually every other CDC-ACM device, but spammy if an Arduino, 3D printer board, or modem happens to share the bus.

Single-file change to `__main__.py`. No new dependencies, no new config options, no changes to `device_usb.py`, `device_ble.py`, `device_base.py`, or `config_loader.py`.

### What's in the allowlist and why

The `TOURBOX_USB_IDS` set added in this PR contains exactly one pair:

```python
TOURBOX_USB_IDS = frozenset([
    (0xc251, 0x2005),  # TourBox Elite, Elite Plus (TourBoxTech via Keil VID)
])
```

This pair was included because it has four independent sources of corroboration:

1. **`lsusb` on a connected TourBox Elite Plus** reports `Bus 003 Device 016: ID c251:2005 Keil Software, Inc. TourBox Elite Plus`.
2. **Sysfs on the same device:** `/sys/.../idVendor` reads `c251`, `idProduct` reads `2005`, `manufacturer` reads `TourBoxTech`. So `lsusb`'s "Keil Software, Inc." name comes from the public `usb.ids` lookup of `c251`; the device itself self-identifies as TourBoxTech via the iManufacturer string descriptor. TourBox is piggybacking on Keil's registered VID, which is common for small vendors.
3. **`device_base.py:887,977,1045`** declares the project's virtual-input device with `vendor=0xC251, product=0x2005`. This is the only VID:PID pair the project itself uses for its uinput identity.
4. **`docs/technical/TOURBOX_ELITE_PROTOCOL_SOLVED.md:53,293`** explicitly documents `Vendor 0xc251, Product 0x2005` as the Elite USB IDs.

### What's not in the allowlist and why

Two other sources of candidate VID:PID pairs were considered and excluded. Documenting the reasoning here so future contributors can extend the list deliberately.

**Excluded: `(0x0483, 0x5741)` and `(0x0483, 0x5740)` from `device_usb.py:34-37`**

The constants `USB_VID = 0x0483 / USB_PID_ELITE = 0x5741 / USB_PID_AMBIGUOUS = 0x5740` are defined but **not referenced anywhere else** in the codebase (verified by grep). They appear to be informational notes from earlier investigation work.

The bigger problem: **`0483:5740` is documented in `usb.ids` as "Virtual COM Port"**, the stock STM32 USB-CDC class driver default. Any STM32 hobbyist board (BluePill, Nucleo, Discovery, custom firmware) running the example USB-CDC code reports this exact pair. Adding it to the allowlist would re-introduce exactly the probe-spam this PR fixes, just narrowed to a different (still huge) population of devices.

`0483:5741` isn't in `usb.ids` at all. The only source for it being a TourBox is the `device_usb.py` comment that says "Confirmed Elite" without further evidence, so I treated it as not corroborated.

The case for "old TourBox firmware reports as STMicro VID" is real but speculative. It's handled by the manufacturer-string fallback below: if such a unit exists, it'll be probed via the fallback path, the unrecognized pair will appear in an INFO log, and the next contributor can promote it to the explicit allowlist with a one-line addition.

**Excluded: the 117 pairs in the bundled `SiLabsUSBDriver.kext`**

I extracted the official TourBox Mac installer (`TourBoxInstall5.12.0Beta3.pkg`) and inspected its bundles to look for an authoritative VID:PID list. Findings:

- The app ships `Contents/Resources/SiLabsUSBDriver.kext` with 117 `IOKitPersonalities` entries.
- All 117 are Silicon Labs' standard CP210x device list. None mention TourBox by name. Our Elite Plus's `c251:2005` is not in the list.
- This is just the stock SiLabs kext shipped as a prerequisite, not a TourBox-specific allowlist.
- The `TourBox.bundle` plugin has no `IOKitPersonalities` matching dictionaries at all.

Net: even the vendor's own Mac driver doesn't ship a fixed VID:PID list specifically for TourBox. So a small confirmed-only allowlist plus a manufacturer-string escape hatch is more accurate than a wide hardcoded list copied from any of these sources.

### Approach

Add a sysfs lookup helper that reads `idVendor`, `idProduct`, and `manufacturer` from `/sys/class/tty/<name>/device/..` and a tri-state classifier that decides whether a given `/dev/ttyACM*` port is worth probing.

Three outcomes:

1. **Probe (fast path).** `(vid, pid)` matches an entry in `TOURBOX_USB_IDS`. No extra logging.
2. **Probe (fallback path).** `(vid, pid)` doesn't match the allowlist, but the iManufacturer string contains `"tourbox"` (case-insensitive). Logs an INFO line surfacing the unrecognized pair so it can be promoted later.
3. **Skip.** Sysfs positively identifies the port as some other device. Logs a DEBUG line on first sight per port (suppressed thereafter, since the supervisor rescans every 3s and we don't want a non-TourBox device on the bus to spam the log every tick).

Sysfs read failures (older kernels, unusual udev, partial reads) return `None`, and the caller falls through to probing. This preserves master behavior on any system where the new path can't help.

The filter applies at both `find_tuxbox_usb_port()` entry points: the configured-port path *and* the scan loop. The configured-port path is the realistic hot path under the current supervisor (it's called every rescan with `configured_usb_port='/dev/ttyACM0'`), so leaving it unfiltered would defeat the point.

### Test cases

Exercised against the running systemd user service on TourBox Elite Plus, CachyOS, KDE Wayland. Cases marked **(real)** use the live device and real journal excerpts; **(simulated)** cases spoof the sysfs resolver to cover behavior we can't reproduce on the local hardware.

#### Case 1: Fast allowlist path (real)
**Setup:** Elite Plus plugged in, default config, allowlist contains `(0xc251, 0x2005)`. Restart service.
**Expected:** Device detected, no extra logging from the filter.
**Observed:**
```
__main__   Found TourBox at /dev/ttyACM0 (26 bytes)
__main__   Auto-detected TourBox at /dev/ttyACM0
device_usb TourBox Elite USB ready!
```
**Status:** Pass. Same end-to-end timing as #43 (~600ms service-start to USB-ready).

#### Case 2: Manufacturer-string fallback path (real)
**Setup:** Elite Plus plugged in. Temporarily comment out `(0xc251, 0x2005)` from `TOURBOX_USB_IDS` to force the allowlist miss. Clear `__pycache__`, restart service.
**Expected:** Device still detected, but via the fallback path, with an INFO log line surfacing the unrecognized pair.
**Observed:**
```
__main__   /dev/ttyACM0 reports unrecognized USB ID c251:2005 with manufacturer 'TourBoxTech'; probing anyway
__main__   Found TourBox at /dev/ttyACM0 (26 bytes)
__main__   Auto-detected TourBox at /dev/ttyACM0
device_usb TourBox Elite USB ready!
```
**Status:** Pass. Allowlist restored after this test.

#### Case 3: Non-TourBox CDC-ACM device skipped, once-per-port log (simulated)
**Setup:** Spoof `_read_sysfs_usb_attrs` to return Arduino-like attributes (`{'vid': 0x2341, 'pid': 0x0043, 'manufacturer': 'Arduino LLC'}`). Call `_probe_if_eligible('/dev/ttyACM0')` 5 times, then a new port `/dev/ttyACM1` 3 times, then back to `/dev/ttyACM0` 2 more times.
**Expected:** `False` returned for every call. Skip log emitted exactly once for `/dev/ttyACM0`, exactly once for `/dev/ttyACM1`, never on the re-visit. No unlock bytes ever written.
**Observed:** 1 / 1 / 0 skip log lines respectively. All eight calls return `False`.
**Status:** Pass. Confirms the suppression set works; a non-TourBox device on the bus produces one DEBUG line per port per process lifetime, not per tick.

#### Case 4: Sysfs lookup unusable, fall through to probe (simulated)
**Setup:** Spoof `_read_sysfs_usb_attrs` to return either `None` (full failure: older kernel, missing /sys) or a partial dict like `{'manufacturer': 'unknown'}` (vid/pid unreadable).
**Expected:** `_is_likely_tourbox()` returns `None` in both sub-cases; caller falls through to `probe_usb_device()` exactly as in master.
**Observed:** Returns `None` for both inputs.
**Status:** Pass. Master behavior preserved on systems where the new path can't help.

#### Case 5: Hypothetical old-firmware variant, STMicro VID + TourBox manufacturer (simulated)
**Setup:** Spoof `_read_sysfs_usb_attrs` to return `{'vid': 0x0483, 'pid': 0x5740, 'manufacturer': 'TourBoxTech'}`.
**Expected:** `_is_likely_tourbox()` returns `True` via the manufacturer-string fallback, with INFO log.
**Observed:**
```
__main__   /dev/ttyACM0 reports unrecognized USB ID 0483:5740 with manufacturer 'TourBoxTech'; probing anyway
```
Returns `True`.
**Status:** Pass.

#### Case 6: Cable replug during active USB session, regression check on #43 (real)
**Setup:** Service running, USB connected. Unplug, wait ~10s, replug.
**Expected:** Existing `device_usb.py` reconnect logic still works (filter is exercised on the configured port; sysfs returns the matching IDs; fast allowlist path).
**Observed:** ~5s outage, fully automatic reconnect, no filter regression. Buttons confirmed working post-reconnect.
**Status:** Pass.

### Test plan for reviewers

- [ ] `python -m tuxbox -v` with cable plugged in. Service should detect via the fast allowlist path. Logs should NOT contain `unrecognized USB ID`.
- [ ] Comment out the `(0xc251, 0x2005)` entry in `TOURBOX_USB_IDS`, clear `__pycache__`, restart. Service should detect via the manufacturer-string fallback and emit `reports unrecognized USB ID ... with manufacturer 'TourBoxTech'; probing anyway`. Restore the entry afterward.
- [ ] If a non-TourBox CDC-ACM device is on hand (Arduino, etc.): plug it in alongside the TourBox. Run the supervisor in BLE mode (cable unplugged at startup, then plugged in). `journalctl --user -u tuxbox -f` should not show probe-attempts to the non-TourBox device.

### Behavioral changes

| Scenario | Before | After |
|---|---|---|
| Elite / Elite Plus, normal use | Probed every rescan | Probed via allowlist (fast path), no extra logging |
| Hypothetical TourBox firmware variant with unrecognized VID:PID, mfr "TourBoxTech" | Probed | Probed via manufacturer-string fallback, with INFO log surfacing the new pair |
| Non-TourBox CDC-ACM device on shared bus (Arduino, 3D printer, modem) | Received unlock bytes every `USB_RESCAN_INTERVAL` | Skipped before probe; one DEBUG log per port per process |
| Older kernel, no sysfs, or unreadable attributes | Probed | Probed (fall-through preserves master behavior) |
| User explicitly configures `--port` or `usb_port=` to a non-TourBox device whose sysfs metadata is readable | Probed once at startup | Skipped if sysfs identifies it as something else. Fall-through if sysfs unreadable. |

The last row is the only meaningful shift outside the spam reduction. Anyone relying on `--port` to force-probe a sysfs-identified non-TourBox device would need to extend the allowlist or the manufacturer hint.

### Pre-existing behavior preserved

- Polling-based detection (3-second `glob.glob`) is unchanged. The pyudev / event-driven follow-up noted in #43 is still open.
- Symmetric USB-to-BLE promotion (the deferred direction from #43) is not addressed here.
- The hardcoded `"TourBox Elite USB ready!"` log string in `device_usb.py:209` is not addressed.

### AI use disclosure

The fix design and PR text were drafted with assistance from an LLM (Claude). Hardware testing against the Elite Plus, log analysis, manufacturer Mac installer extraction, the `usb.ids` cross-reference, and end-to-end validation against the running service were performed manually.
